### PR TITLE
Add strategy pattern sample

### DIFF
--- a/src/JiraClient.Sample/Strategies/GitHubStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/GitHubStrategy.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+
+namespace JiraClient.Sample.Strategies;
+
+public class GitHubStrategy : IApiClientStrategy
+{
+    private readonly HttpClient _httpClient;
+
+    public GitHubStrategy(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task RunAsync()
+    {
+        var response = await _httpClient.GetAsync("repos/dotnet/runtime");
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(json);
+    }
+}

--- a/src/JiraClient.Sample/Strategies/IApiClientStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/IApiClientStrategy.cs
@@ -1,0 +1,6 @@
+namespace JiraClient.Sample.Strategies;
+
+public interface IApiClientStrategy
+{
+    Task RunAsync();
+}

--- a/src/JiraClient.Sample/Strategies/JiraStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/JiraStrategy.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Text.Json;
+using JiraClient;
+
+namespace JiraClient.Sample.Strategies;
+
+public class JiraStrategy : IApiClientStrategy
+{
+    private readonly IJiraClient _client;
+
+    public JiraStrategy(IJiraClient client)
+    {
+        _client = client;
+    }
+
+    public async Task RunAsync()
+    {
+        var issue = await _client.GetIssueAsync("TEST-1");
+        Console.WriteLine(JsonSerializer.Serialize(issue, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/src/JiraClient.Sample/Strategies/PagerDutyStrategy.cs
+++ b/src/JiraClient.Sample/Strategies/PagerDutyStrategy.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+
+namespace JiraClient.Sample.Strategies;
+
+public class PagerDutyStrategy : IApiClientStrategy
+{
+    private readonly HttpClient _httpClient;
+
+    public PagerDutyStrategy(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task RunAsync()
+    {
+        var response = await _httpClient.GetAsync("incidents.json");
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(json);
+    }
+}


### PR DESCRIPTION
## Summary
- extend console sample to choose GitHub or PagerDuty strategies
- implement strategy classes for Jira, GitHub and PagerDuty

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b68dc0ed0832fa29fce4d12690a73