### PR TITLE
Add metric profiles and syslog logging

### DIFF
--- a/src/GitHubClient/GitHubClientImpl.cs
+++ b/src/GitHubClient/GitHubClientImpl.cs
@@ -25,4 +25,11 @@ public class GitHubClientImpl : IGitHubClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<GitHubRepo>();
     }
+
+    public async Task<string> GetRawAsync(string path)
+    {
+        var response = await _httpClient.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
 }

--- a/src/GitHubClient/IGitHubClient.cs
+++ b/src/GitHubClient/IGitHubClient.cs
@@ -5,4 +5,5 @@ namespace GitHubClient;
 public interface IGitHubClient
 {
     Task<GitHubRepo?> GetRepoAsync(string owner, string repo);
+    Task<string> GetRawAsync(string path);
 }

--- a/src/JiraClient/IJiraClient.cs
+++ b/src/JiraClient/IJiraClient.cs
@@ -10,4 +10,5 @@ public interface IJiraClient
     /// <param name="issueKey">The issue key, e.g. "TEST-1".</param>
     /// <returns>The deserialized <see cref="JiraIssue"/>.</returns>
     Task<JiraIssue> GetIssueAsync(string issueKey);
+    Task<string> GetRawAsync(string path);
 }

--- a/src/JiraClient/JiraClientImpl.cs
+++ b/src/JiraClient/JiraClientImpl.cs
@@ -32,4 +32,11 @@ public class JiraClientImpl : IJiraClient
         var issue = await JsonSerializer.DeserializeAsync<JiraIssue>(stream) ?? new JiraIssue();
         return issue;
     }
+
+    public async Task<string> GetRawAsync(string path)
+    {
+        var response = await _httpClient.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
 }

--- a/src/MetricsClientSample/MetricProfile.cs
+++ b/src/MetricsClientSample/MetricProfile.cs
@@ -1,0 +1,9 @@
+namespace MetricsClientSample;
+
+public class MetricProfile
+{
+    public string Name { get; set; } = string.Empty;
+    public string Client { get; set; } = string.Empty;
+    public string[] Endpoints { get; set; } = System.Array.Empty<string>();
+    public string[] Properties { get; set; } = System.Array.Empty<string>();
+}

--- a/src/MetricsClientSample/SyslogMetricLogger.cs
+++ b/src/MetricsClientSample/SyslogMetricLogger.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace MetricsClientSample;
+
+public interface IMetricLogger
+{
+    void Log(string metricName, string rawData);
+}
+
+public class SyslogMetricLogger : IMetricLogger
+{
+    public void Log(string metricName, string rawData)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK");
+        var host = Environment.MachineName;
+        Console.WriteLine($"{timestamp} {host} MetricsClientSample: {metricName} {rawData}");
+    }
+}

--- a/src/MetricsClientSample/appsettings.Development.json
+++ b/src/MetricsClientSample/appsettings.Development.json
@@ -35,15 +35,23 @@
     }
   },
   "MetricProfiles": {
-    "jira-bug-count": {
-      "Client": "jira",
-      "Endpoint": "/rest/api/2/search",
-      "Description": "Collect number of open bugs"
+    "github-branch-count": {
+      "Name": "Number of Branches",
+      "Client": "github",
+      "Endpoints": ["repos/dotnet/runtime/branches"],
+      "Properties": ["name"]
     },
-    "pagerduty-mtta": {
+    "pagerduty-acknowledged": {
+      "Name": "Acknowledged Alerts",
       "Client": "pagerduty",
-      "Endpoint": "incidents.json",
-      "Description": "Collect acknowledgement times for incidents to compute MTTA"
+      "Endpoints": ["incidents.json?statuses=acknowledged"],
+      "Properties": ["incidents.id", "incidents.status", "incidents.summary"]
+    },
+    "jira-open-reviews": {
+      "Name": "Open Incident Reviews",
+      "Client": "jira",
+      "Endpoints": ["/rest/api/2/search?jql=project=INCIDENT%20AND%20status=\"In%20Review\""],
+      "Properties": ["issues.id", "issues.key", "issues.fields.summary", "issues.fields.status.name"]
     }
   }
 }

--- a/src/MetricsClientSample/appsettings.Production.json
+++ b/src/MetricsClientSample/appsettings.Production.json
@@ -35,15 +35,23 @@
     }
   },
   "MetricProfiles": {
-    "jira-bug-count": {
-      "Client": "jira",
-      "Endpoint": "/rest/api/2/search",
-      "Description": "Collect number of open bugs"
+    "github-branch-count": {
+      "Name": "Number of Branches",
+      "Client": "github",
+      "Endpoints": ["repos/dotnet/runtime/branches"],
+      "Properties": ["name"]
     },
-    "pagerduty-mtta": {
+    "pagerduty-acknowledged": {
+      "Name": "Acknowledged Alerts",
       "Client": "pagerduty",
-      "Endpoint": "incidents.json",
-      "Description": "Collect acknowledgement times for incidents to compute MTTA"
+      "Endpoints": ["incidents.json?statuses=acknowledged"],
+      "Properties": ["incidents.id", "incidents.status", "incidents.summary"]
+    },
+    "jira-open-reviews": {
+      "Name": "Open Incident Reviews",
+      "Client": "jira",
+      "Endpoints": ["/rest/api/2/search?jql=project=INCIDENT%20AND%20status=\"In%20Review\""],
+      "Properties": ["issues.id", "issues.key", "issues.fields.summary", "issues.fields.status.name"]
     }
   }
 }

--- a/src/PagerDutyClient/IPagerDutyClient.cs
+++ b/src/PagerDutyClient/IPagerDutyClient.cs
@@ -5,4 +5,5 @@ namespace PagerDutyClient;
 public interface IPagerDutyClient
 {
     Task<PagerDutyIncidentList?> GetIncidentsAsync();
+    Task<string> GetRawAsync(string path);
 }

--- a/src/PagerDutyClient/PagerDutyClientImpl.cs
+++ b/src/PagerDutyClient/PagerDutyClientImpl.cs
@@ -21,4 +21,11 @@ public class PagerDutyClientImpl : IPagerDutyClient
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<PagerDutyIncidentList>();
     }
+
+    public async Task<string> GetRawAsync(string path)
+    {
+        var response = await _httpClient.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- add metrics profiles describing metrics to collect
- extend clients with raw endpoint access
- add a simple syslog logger abstraction
- use metric profiles in the sample app to choose a client and log raw data

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cb940d3a8832fbde42e0f6ea0736c