### PR TITLE
Expose HTTP handlers for testing

### DIFF
--- a/src/GitHubClient/PatHttpMessageHandler.cs
+++ b/src/GitHubClient/PatHttpMessageHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace GitHubClient;
 
-internal class PatHttpMessageHandler : DelegatingHandler
+public class PatHttpMessageHandler : DelegatingHandler
 {
     private readonly GitHubOptions _options;
 

--- a/src/JiraClient/OAuthHttpMessageHandler.cs
+++ b/src/JiraClient/OAuthHttpMessageHandler.cs
@@ -3,7 +3,7 @@ using System.Net.Http.Headers;
 
 namespace JiraClient;
 
-internal class OAuthHttpMessageHandler : DelegatingHandler
+public class OAuthHttpMessageHandler : DelegatingHandler
 {
     private readonly IOAuthTokenProvider _tokenProvider;
 

--- a/src/PagerDutyClient/ApiKeyHttpMessageHandler.cs
+++ b/src/PagerDutyClient/ApiKeyHttpMessageHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace PagerDutyClient;
 
-internal class ApiKeyHttpMessageHandler : DelegatingHandler
+public class ApiKeyHttpMessageHandler : DelegatingHandler
 {
     private readonly PagerDutyOptions _options;
 


### PR DESCRIPTION
## Summary
- Make HTTP handlers public so they can be used by unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f357e7834832f864498505ac0e40c