### PR TITLE
Document metric profiles in appsettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ For GitHub and PagerDuty, supply `GitHub:PersonalAccessToken` and `PagerDuty:Api
 in the configuration (or as environment variables `GitHub__PersonalAccessToken`
 and `PagerDuty__ApiKey`) to authenticate requests.
 
+## Metric Profiles
+
+Metric profiles describe which client, endpoints, and fields the sample
+application should query. Profiles are defined in the `MetricProfiles`
+section of the appsettings files:
+
+```json
+"MetricProfiles": {
+  "github-branch-count": {
+    "Name": "Number of Branches",
+    "Client": "github",
+    "Endpoints": ["repos/dotnet/runtime/branches"],
+    "Properties": ["name"]
+  }
+}
+```
+
+Each profile specifies:
+
+- `Client` – one of `jira`, `github`, or `pagerduty`.
+- `Endpoints` – API paths relative to the chosen client's base address.
+- `Properties` – JSON properties to extract and log from each response.
+
+Run the sample by passing the profile key as the first command-line argument:
+
+```bash
+dotnet run --project src/MetricsClientSample -- github-branch-count
+```
+
+The application will call each endpoint and log the configured properties for
+the selected profile.
+
 ## Service Mocks
 
 The folder `mountebank` contains an `imposters.json` file describing HTTP mocks

--- a/src/GitHubClient/README.md
+++ b/src/GitHubClient/README.md
@@ -20,3 +20,27 @@ var repo = await client.GetRepoAsync("octocat", "Hello-World");
 ```
 
 The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided.  If a `GitHub:PersonalAccessToken` value is supplied in configuration, an `Authorization` header is automatically added to each request.
+
+## Metric Profiles
+
+The `MetricsClientSample` project can drive this client using metric profiles
+defined in the `MetricProfiles` section of `appsettings.*.json`.
+Each profile identifies the client to use, the endpoints to call, and the
+JSON properties to log.
+
+```json
+"MetricProfiles": {
+  "github-branch-count": {
+    "Name": "Number of Branches",
+    "Client": "github",
+    "Endpoints": ["repos/dotnet/runtime/branches"],
+    "Properties": ["name"]
+  }
+}
+```
+
+Run the sample with:
+
+```bash
+dotnet run --project src/MetricsClientSample -- github-branch-count
+```

--- a/src/PagerDutyClient/README.md
+++ b/src/PagerDutyClient/README.md
@@ -20,3 +20,26 @@ var incidents = await client.GetIncidentsAsync();
 ```
 
 The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set. If a `PagerDuty:ApiKey` is configured, an `Authorization` header is added using the `Token token=` format.
+
+## Metric Profiles
+
+`MetricsClientSample` can retrieve PagerDuty data via metric profiles declared in
+`appsettings.*.json`. A profile specifies the client name, endpoints, and
+response properties to record.
+
+```json
+"MetricProfiles": {
+  "pagerduty-acknowledged": {
+    "Name": "Acknowledged Alerts",
+    "Client": "pagerduty",
+    "Endpoints": ["incidents.json?statuses=acknowledged"],
+    "Properties": ["incidents.id", "incidents.status", "incidents.summary"]
+  }
+}
+```
+
+Run the sample profile with:
+
+```bash
+dotnet run --project src/MetricsClientSample -- pagerduty-acknowledged
+```


### PR DESCRIPTION
## Summary
- explain how to configure metric profiles in appsettings
- note how to run the sample with a metric profile
- mention metric profile usage in GitHubClient and PagerDutyClient docs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f37235490832f856ce755224f8efd