### PR TITLE
Add developer API details for each client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ For GitHub and PagerDuty, supply `GitHub:PersonalAccessToken` and `PagerDuty:Api
 in the configuration (or as environment variables `GitHub__PersonalAccessToken`
 and `PagerDuty__ApiKey`) to authenticate requests.
 
+## Developer Credentials and API Endpoints
+
+### Jira
+
+Create OAuth credentials for your site in the
+[Atlassian Developer Console](https://developer.atlassian.com/console/myapps/)
+to obtain the client id, client secret, and refresh token. Jira Cloud's REST
+API is served from `https://your-domain.atlassian.net/rest/api/2`.
+
+### GitHub
+
+Generate a personal access token from
+[GitHub's token settings](https://github.com/settings/tokens) with the scopes
+required by your application. The GitHub REST API is available at
+`https://api.github.com`.
+
+### PagerDuty
+
+Create a REST API key in the PagerDuty web UI under
+**Integrations → API Access Keys**. PagerDuty's developer API base URL is
+`https://api.pagerduty.com`.
+
 ## Metric Profiles
 
 Metric profiles describe which client, endpoints, and fields the sample


### PR DESCRIPTION
## Summary
- document where to obtain credentials and the base URL for Jira's REST API
- add GitHub token retrieval instructions and its API endpoint
- note how to generate PagerDuty API keys and its API base address

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `curl -SL https://dot.net/v1/dotnet-install.sh` *(fails: 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688f41c2992c832fb6aa5716884ea2dc