### PR TITLE
Add launch settings for container debugging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,8 @@
         "ms-dotnettools.csharp"
       ]
     }
+  },
+  "containerEnv": {
+    "DOTNET_ENVIRONMENT": "Development"
   }
 }

--- a/src/MetricsClientSample/Properties/launchSettings.json
+++ b/src/MetricsClientSample/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "MetricsClientSample": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- enable DOTNET_ENVIRONMENT=Development inside devcontainer
- add launch settings with development environment for MetricsClientSample

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f87cfea94832fafda392cacafd2a7