### PR TITLE
Add VS Code launch configuration with metric profile argument

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MetricsClientSample Debug",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/src/MetricsClientSample/bin/Debug/net8.0/MetricsClientSample.dll",
+      "args": ["github-branch-count"],
+      "cwd": "${workspaceFolder}/src/MetricsClientSample",
+      "console": "integratedTerminal",
+      "stopAtEntry": false
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/MetricsAggregator.sln"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `.vscode/launch.json` for debugging MetricsClientSample with default `github-branch-count` metric profile argument
- include build task for solution in `.vscode/tasks.json`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f965eb4f8832facc608285aaee48b