### PR TITLE
Start mountebank on devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": "dotnet restore",
+  "postStartCommand": "cd mountebank && ./start-mountebank.sh &",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- Start mountebank automatically when the development container launches

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688faef6c244832f8c46e125c4292021