### PR TITLE
Add dummy dev credentials for GitHub and PagerDuty

### DIFF
--- a/src/MetricsClientSample/appsettings.Development.json
+++ b/src/MetricsClientSample/appsettings.Development.json
@@ -9,10 +9,10 @@
     }
   },
   "GitHub": {
-    "PersonalAccessToken": ""
+    "PersonalAccessToken": "dummy-personal-access-token"
   },
   "PagerDuty": {
-    "ApiKey": ""
+    "ApiKey": "dummy-pagerduty-api-key"
   },
   "Mappings": {
     "jira": {


### PR DESCRIPTION
## Summary
- add example personal access token and API key placeholders in developer app settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688faf744c18832fa29ab68299a46705