### PR TITLE
Make GitHub and PagerDuty base URLs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ configuration section looks like:
 as `Jira__OAuth__ClientId` or `Jira__OAuth__RefreshToken` can be supplied at
 runtime without modifying the JSON files.
 
-For GitHub and PagerDuty, supply `GitHub:PersonalAccessToken` and `PagerDuty:ApiKey`
-in the configuration (or as environment variables `GitHub__PersonalAccessToken`
-and `PagerDuty__ApiKey`) to authenticate requests.
+For GitHub and PagerDuty, supply `GitHub:BaseUrl`, `GitHub:PersonalAccessToken`,
+`PagerDuty:BaseUrl`, and `PagerDuty:ApiKey` in the configuration (or as environment
+variables `GitHub__BaseUrl`, `GitHub__PersonalAccessToken`, `PagerDuty__BaseUrl`,
+and `PagerDuty__ApiKey`) to configure endpoints and authenticate requests.
 
 ## Developer Credentials and API Endpoints
 

--- a/src/GitHubClient/GitHubClientImpl.cs
+++ b/src/GitHubClient/GitHubClientImpl.cs
@@ -1,18 +1,21 @@
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace GitHubClient;
 
 public class GitHubClientImpl : IGitHubClient
 {
     private readonly HttpClient _httpClient;
+    private readonly GitHubOptions _options;
 
-    public GitHubClientImpl(HttpClient httpClient)
+    public GitHubClientImpl(HttpClient httpClient, IOptions<GitHubOptions> options)
     {
         _httpClient = httpClient;
+        _options = options.Value;
         if (_httpClient.BaseAddress == null)
-            _httpClient.BaseAddress = new System.Uri("https://api.github.com/");
+            _httpClient.BaseAddress = new System.Uri(_options.BaseUrl);
         if (!_httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("metricsclientsample"))
         {
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("metricsclientsample");

--- a/src/GitHubClient/GitHubOptions.cs
+++ b/src/GitHubClient/GitHubOptions.cs
@@ -2,5 +2,6 @@ namespace GitHubClient;
 
 public class GitHubOptions
 {
+    public string BaseUrl { get; set; } = "https://api.github.com/";
     public string PersonalAccessToken { get; set; } = string.Empty;
 }

--- a/src/GitHubClient/README.md
+++ b/src/GitHubClient/README.md
@@ -19,7 +19,7 @@ Fetch repository information with `GetRepoAsync`:
 var repo = await client.GetRepoAsync("octocat", "Hello-World");
 ```
 
-The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided.  If a `GitHub:PersonalAccessToken` value is supplied in configuration, an `Authorization` header is automatically added to each request.
+The client defaults the `BaseAddress` to `https://api.github.com/` and adds a `User-Agent` header if one is not provided. Setting a `GitHub:BaseUrl` configuration value overrides the base address. If a `GitHub:PersonalAccessToken` value is supplied, an `Authorization` header is automatically added to each request.
 
 ## Metric Profiles
 

--- a/src/MetricsClientSample/appsettings.Development.json
+++ b/src/MetricsClientSample/appsettings.Development.json
@@ -9,9 +9,11 @@
     }
   },
   "GitHub": {
+    "BaseUrl": "http://localhost:4546/",
     "PersonalAccessToken": "dummy-personal-access-token"
   },
   "PagerDuty": {
+    "BaseUrl": "http://localhost:4547/api/v2/",
     "ApiKey": "dummy-pagerduty-api-key"
   },
   "Mappings": {

--- a/src/MetricsClientSample/appsettings.Production.json
+++ b/src/MetricsClientSample/appsettings.Production.json
@@ -9,9 +9,11 @@
     }
   },
   "GitHub": {
+    "BaseUrl": "https://api.github.com/",
     "PersonalAccessToken": "set-in-env"
   },
   "PagerDuty": {
+    "BaseUrl": "https://status.pagerduty.com/api/v2/",
     "ApiKey": "set-in-env"
   },
   "Mappings": {

--- a/src/PagerDutyClient/PagerDutyClientImpl.cs
+++ b/src/PagerDutyClient/PagerDutyClientImpl.cs
@@ -1,18 +1,21 @@
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace PagerDutyClient;
 
 public class PagerDutyClientImpl : IPagerDutyClient
 {
     private readonly HttpClient _httpClient;
+    private readonly PagerDutyOptions _options;
 
-    public PagerDutyClientImpl(HttpClient httpClient)
+    public PagerDutyClientImpl(HttpClient httpClient, IOptions<PagerDutyOptions> options)
     {
         _httpClient = httpClient;
+        _options = options.Value;
         if (_httpClient.BaseAddress == null)
-            _httpClient.BaseAddress = new System.Uri("https://status.pagerduty.com/api/v2/");
+            _httpClient.BaseAddress = new System.Uri(_options.BaseUrl);
     }
 
     public async Task<PagerDutyIncidentList?> GetIncidentsAsync()

--- a/src/PagerDutyClient/PagerDutyOptions.cs
+++ b/src/PagerDutyClient/PagerDutyOptions.cs
@@ -2,5 +2,6 @@ namespace PagerDutyClient;
 
 public class PagerDutyOptions
 {
+    public string BaseUrl { get; set; } = "https://status.pagerduty.com/api/v2/";
     public string ApiKey { get; set; } = string.Empty;
 }

--- a/src/PagerDutyClient/README.md
+++ b/src/PagerDutyClient/README.md
@@ -19,7 +19,7 @@ Retrieve current incidents with `GetIncidentsAsync`:
 var incidents = await client.GetIncidentsAsync();
 ```
 
-The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set. If a `PagerDuty:ApiKey` is configured, an `Authorization` header is added using the `Token token=` format.
+The HTTP client's base address defaults to `https://status.pagerduty.com/api/v2/` if not set. Providing a `PagerDuty:BaseUrl` configuration value overrides the base address. If a `PagerDuty:ApiKey` is configured, an `Authorization` header is added using the `Token token=` format.
 
 ## Metric Profiles
 


### PR DESCRIPTION
## Summary
- allow GitHub and PagerDuty clients to take their base address from configuration
- document new GitHub:BaseUrl and PagerDuty:BaseUrl settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890bfea8f0c832f9935582d0b208889